### PR TITLE
3mfcompatibility

### DIFF
--- a/Spec.md
+++ b/Spec.md
@@ -21,7 +21,7 @@ Properties:
 * r, double representing the radius
 
 ###Beams
-A line connecting two nodes. If the nodes have diameters defined, the beam has a thickness. The thickness at any given point along the beam is defined by an interpolation function. The default interpolation function in linear.
+A connection between two nodes. If the nodes have radii defined, the beam has a thickness. The thickness at any given point along the beam is defined by an interpolation function. The default interpolation function is linear.
 
 Properties:
 * id, unique (within beams) integer

--- a/lib/source/LTCModel.cpp
+++ b/lib/source/LTCModel.cpp
@@ -58,7 +58,7 @@ namespace LTC {
       }
       auto graph = LTCGraph::create(name, id);
 
-      auto nodes = graphX->FirstChildElement("nodes");
+      auto nodes = graphX->FirstChildElement("nodegroup");
       if (!nodes) {
         return LTC_ERROR::LTC_NO_NODES;
       }
@@ -80,7 +80,7 @@ namespace LTC {
         currentNode = currentNode->NextSiblingElement("node");
       } while (currentNode);
 
-      auto beams = nodes->NextSiblingElement("beams");
+      auto beams = nodes->NextSiblingElement("beamgroup");
       if (!beams) {
         return LTC_ERROR::LTC_NO_BEAMS;
       }
@@ -100,7 +100,7 @@ namespace LTC {
 
       mGraphs.push_back(graph);
 
-      graphX = graphX->NextSiblingElement("lattice");
+      graphX = graphX->NextSiblingElement("graph");
     } while (graphX);
     return LTC_ERROR::OK;
   }
@@ -114,7 +114,7 @@ namespace LTC {
       auto graphX = doc->NewElement("graph");
       graphX->SetAttribute("id", graph->getID());
       graphX->SetAttribute("name", graph->getName().c_str());
-      auto nodesX = graphX->InsertEndChild(doc->NewElement("nodes"));
+      auto nodesX = graphX->InsertEndChild(doc->NewElement("nodegroup"));
 
       const auto& nodes = graph->getNodes();
       int count = 0;
@@ -131,7 +131,7 @@ namespace LTC {
         count++;
       }
 
-      auto beamsX = graphX->InsertEndChild(doc->NewElement("beams"));
+      auto beamsX = graphX->InsertEndChild(doc->NewElement("beamgroup"));
 
       const auto& beams = graph->getBeams();
       count = 0;

--- a/lib/source/LTCModel.cpp
+++ b/lib/source/LTCModel.cpp
@@ -107,15 +107,22 @@ namespace LTC {
 
   LTC::LTC_ERROR LTCModel::write(const char* path)
   {
+    //Make new XML Doc
     auto doc = std::make_unique<XMLDocument>();
+    //Insert XML declaration header
     auto dec = doc->NewDeclaration();
     doc->InsertFirstChild(dec);
+
+    //Loop through graph objects & insert graph elements
     for (auto& graph : mGraphs) {
       auto graphX = doc->NewElement("graph");
       graphX->SetAttribute("id", graph->getID());
       graphX->SetAttribute("name", graph->getName().c_str());
+
+      //add element for nodegroup
       auto nodesX = graphX->InsertEndChild(doc->NewElement("nodegroup"));
 
+      //Loop through nodes & insert node elements
       const auto& nodes = graph->getNodes();
       int count = 0;
       for (auto& n : nodes) {
@@ -131,8 +138,10 @@ namespace LTC {
         count++;
       }
 
+      //add element for bamgroup
       auto beamsX = graphX->InsertEndChild(doc->NewElement("beamgroup"));
 
+      //Loop through beams & add beam elements
       const auto& beams = graph->getBeams();
       count = 0;
       for (auto& b : beams) {
@@ -143,6 +152,8 @@ namespace LTC {
         beamsX->InsertEndChild(newBeam);
         count++;
       }
+
+      //add graph to document
       doc->InsertEndChild(graphX);
       count++;
     }

--- a/lib/vc14/libNTLatticeGraph.vcxproj.user
+++ b/lib/vc14/libNTLatticeGraph.vcxproj.user
@@ -4,4 +4,8 @@
     <LocalDebuggerCommandArguments>..\..\samples\SampleCube.ltcx</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LocalDebuggerCommandArguments>..\..\samples\SampleCube.ltcx</LocalDebuggerCommandArguments>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
 </Project>

--- a/samples/SampleCube.ltcx
+++ b/samples/SampleCube.ltcx
@@ -2,7 +2,7 @@
 
 
 <graph id ="0" name ="cube unit">
-  <nodes>
+  <nodegroup>
     <node id="0" x="-1.0" y="-1.0" z="-1.0" rad="1."/>
     <node id="1" x="1.0"  y="-1.0" z="-1.0" rad="1."/>
     <node id="2" x="1.0"  y="1.0"  z="-1.0" rad="1."/>
@@ -11,9 +11,9 @@
     <node id="5" x="1.0"  y="-1.0" z="1.0"  rad="1."/>
     <node id="6" x="1.0"  y="1.0"  z="1.0"  rad="1."/>
     <node id="7" x="-1.0" y="1.0"  z="1.0"  rad="1."/>
-  </nodes>
+  </nodegroup>
 
-  <beams>
+  <beamgroup>
     <beam id="0" n1="0"  n2="1"/>
     <beam id="1" n1="1"  n2="2"/>
     <beam id="2" n1="2"  n2="3"/>
@@ -26,6 +26,6 @@
     <beam id="9" n1="1"  n2="5"/>
     <beam id="10" n1="2" n2="6"/>
     <beam id="11" n1="3" n2="7"/>
-  </beams>
+  </beamgroup>
 
 </graph>

--- a/samples/Sample_Out.ltcx
+++ b/samples/Sample_Out.ltcx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <graph id="0" name="cube unit">
-    <nodes>
+    <nodegroup>
         <node id="0" x="-1" y="-1" z="-1" r="1"/>
         <node id="1" x="1" y="-1" z="-1" r="1"/>
         <node id="2" x="1" y="1" z="-1" r="1"/>
@@ -9,8 +9,8 @@
         <node id="5" x="1" y="-1" z="1" r="1"/>
         <node id="6" x="1" y="1" z="1" r="1"/>
         <node id="7" x="-1" y="1" z="1" r="1"/>
-    </nodes>
-    <beams>
+    </nodegroup>
+    <beamgroup>
         <beam id="0" n1="0" n2="1"/>
         <beam id="1" n1="1" n2="2"/>
         <beam id="2" n1="2" n2="3"/>
@@ -23,5 +23,5 @@
         <beam id="9" n1="1" n2="5"/>
         <beam id="10" n1="2" n2="6"/>
         <beam id="11" n1="3" n2="7"/>
-    </beams>
+    </beamgroup>
 </graph>

--- a/schemas/NTLG_001.xsd
+++ b/schemas/NTLG_001.xsd
@@ -1,52 +1,77 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema targetNamespace="NTLatticeGraph"
-    xmlns="https://github.com/nTopology/NTLatticeGraph/blob/master/schemas/NTLG_001.xsd"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    
-  <xs:annotation>
-    <xs:documentation>
-    This schema defines an NTLatticeGraph.
-    </xs:documentation>
-  </xs:annotation>
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns="http://schemas.microsoft.com/3dmanufacturing/material/2015/02"
+xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xml="http://www.w3.org/XML/1998/namespace"
+targetNamespace="http://schemas.microsoft.com/3dmanufacturing/material/2015/02"
+elementFormDefault="unqualified" attributeFormDefault="unqualified" blockDefault="#all">
+<xs:import namespace="http://www.w3.org/XML/1998/namespace"
+schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+<xs:annotation>
+<xs:documentation><![CDATA[
+Schema notes:
+Items within this schema follow a simple naming convention of appending a prefix indicating the
+type of element for references:
+Unprefixed: Element names
+CT_: Complex types
+ST_: Simple types
+]]></xs:documentation>
+</xs:annotation>
 
+<!-- Complex Types -->
+<xs:complexType name="CT_Node">
+<xs:attribute name="id" type="ST_ResourceID" use="required"/>
+<xs:attribute name="x" type="ST_Number" use="required"/>
+<xs:attribute name="y" type="ST_Number" use="required"/>
+<xs:attribute name="z" type="ST_Number" use="required"/>
+<xs:attribute name="r" type="ST_Number" use="optional"/>
+</xs:complexType>
 
-  <xs:element name="graph">
-    <xs:complexType>
-      <xs:sequence>
+<xs:complexType name="CT_Beam">
+<xs:attribute name="id" type="ST_ResourceID" use="required"/>
+<xs:attribute name="n1" type="ST_ResourceID" use="required"/>
+<xs:attribute name="n2" type="ST_ResourceID" use="required"/>
+</xs:complexType>
 
-        <xs:element name="nodes">
-          <xs:complexType>
-            <xs:sequence>
-              <xs:element name="node">
-                <xs:complexType>
-                  <xs:attribute name="id" type="xs:ID" use="required"/>
-                  <xs:attribute name="x" type="xs:double" use="required"/>
-                  <xs:attribute name="y" type="xs:double" use="required"/>
-                  <xs:attribute name="z" type="xs:double" use="required"/>
-                  <xs:attribute name="r" type="xs:double" use="optional"/>
-                </xs:complexType>
-              </xs:element>
-            </xs:sequence>
-          </xs:complexType>
-        </xs:element>
+<xs:complexType name="CT_NodeGroup">
+<xs:sequence>
+<xs:element ref="node" maxOccurs="2147483647"/>
+</xs:sequence>
+<xs:attribute name="id" type="ST_ResourceID" use="required"/>
+</xs:complexType>
 
-        <xs:element name="beams">
-          <xs:complexType>
-            <xs:sequence>
-            <xs:element name="beam">
-              <xs:complexType>
-                <xs:attribute name="id" type="xs:IDREF" use="required"/>
-                <xs:attribute name="n1" type="xs:double" use="required"/>
-                <xs:attribute name="n2" type="xs:double" use="required"/>
-              </xs:complexType>
-            </xs:element>
-            </xs:sequence>
-          </xs:complexType>
-        </xs:element>
+<xs:complexType name="CT_BeamGroup">
+<xs:sequence>
+<xs:element ref="beam" maxOccurs="2147483647"/>
+</xs:sequence>
+<xs:attribute name="id" type="ST_ResourceID" use="required"/>
+</xs:complexType>
 
-        <xs:attribute name="id" type="ID" use="required"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
+<xs:complexType name="CT_Graph">
+<xs:element ref="nodegroup" />
+<xs:element ref="beamgroup" />
+<xs:attribute name="id" type="ST_ResourceID" use="required"/>
+</xs:complexType>
+
+<!-- Simple Types -->
+</xs:simpleType>
+<xs:simpleType name="ST_ResourceID">
+<xs:restriction base="xs:positiveInteger">
+<xs:maxExclusive value="2147483648"/>
+</xs:restriction>
+</xs:simpleType>
+
+</xs:simpleType>
+<xs:simpleType name="ST_Number">
+<xs:restriction base="xs:double">
+<xs:whiteSpace value="collapse"/>
+<xs:pattern value="((\-|\+)?(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))((e|E)(\-|\+)?[0-9]+)?)"/>
+</xs:restriction>
+</xs:simpleType>
+
+<!-- Elements -->
+<xs:element name="nodegroup" type="CT_NodeGroup"/>
+<xs:element name="beamgroup" type="CT_BeamGroup" />
+<xs:element name="node" type="CT_Node"/>
+<xs:element name="beam" type="CT_Beam"/>
+<xs:element name="graph" type="CT_Graph"/>
 
 </xs:schema>

--- a/schemas/NTLG_001.xsd
+++ b/schemas/NTLG_001.xsd
@@ -49,6 +49,7 @@ ST_: Simple types
 <xs:element ref="nodegroup" />
 <xs:element ref="beamgroup" />
 <xs:attribute name="id" type="ST_ResourceID" use="required"/>
+<xs:attribute name="name" type="xs:string" use="optional"/>
 </xs:complexType>
 
 <!-- Simple Types -->

--- a/schemas/NTLG_001.xsd
+++ b/schemas/NTLG_001.xsd
@@ -1,78 +1,78 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns="http://schemas.microsoft.com/3dmanufacturing/material/2015/02"
-xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xml="http://www.w3.org/XML/1998/namespace"
-targetNamespace="http://schemas.microsoft.com/3dmanufacturing/material/2015/02"
-elementFormDefault="unqualified" attributeFormDefault="unqualified" blockDefault="#all">
-<xs:import namespace="http://www.w3.org/XML/1998/namespace"
-schemaLocation="http://www.w3.org/2001/xml.xsd"/>
-<xs:annotation>
-<xs:documentation><![CDATA[
-Schema notes:
-Items within this schema follow a simple naming convention of appending a prefix indicating the
-type of element for references:
-Unprefixed: Element names
-CT_: Complex types
-ST_: Simple types
-]]></xs:documentation>
-</xs:annotation>
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xml="http://www.w3.org/XML/1998/namespace"
+  targetNamespace="http://schemas.microsoft.com/3dmanufacturing/material/2015/02"
+  elementFormDefault="unqualified" attributeFormDefault="unqualified" blockDefault="#all">
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+    schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+    <xs:annotation>
+      <xs:documentation><![CDATA[
+        Schema notes:
+        Items within this schema follow a simple naming convention of appending a prefix indicating the
+        type of element for references:
+        Unprefixed: Element names
+        CT_: Complex types
+        ST_: Simple types
+        ]]></xs:documentation>
+      </xs:annotation>
 
-<!-- Complex Types -->
-<xs:complexType name="CT_Node">
-<xs:attribute name="id" type="ST_ResourceID" use="required"/>
-<xs:attribute name="x" type="ST_Number" use="required"/>
-<xs:attribute name="y" type="ST_Number" use="required"/>
-<xs:attribute name="z" type="ST_Number" use="required"/>
-<xs:attribute name="r" type="ST_Number" use="optional"/>
-</xs:complexType>
+      <!-- Complex Types -->
+      <xs:complexType name="CT_Node">
+        <xs:attribute name="id" type="ST_ResourceID" use="required"/>
+        <xs:attribute name="x" type="ST_Number" use="required"/>
+        <xs:attribute name="y" type="ST_Number" use="required"/>
+        <xs:attribute name="z" type="ST_Number" use="required"/>
+        <xs:attribute name="r" type="ST_Number" use="optional"/>
+      </xs:complexType>
 
-<xs:complexType name="CT_Beam">
-<xs:attribute name="id" type="ST_ResourceID" use="required"/>
-<xs:attribute name="n1" type="ST_ResourceID" use="required"/>
-<xs:attribute name="n2" type="ST_ResourceID" use="required"/>
-</xs:complexType>
+      <xs:complexType name="CT_Beam">
+        <xs:attribute name="id" type="ST_ResourceID" use="required"/>
+        <xs:attribute name="n1" type="ST_ResourceID" use="required"/>
+        <xs:attribute name="n2" type="ST_ResourceID" use="required"/>
+      </xs:complexType>
 
-<xs:complexType name="CT_NodeGroup">
-<xs:sequence>
-<xs:element ref="node" maxOccurs="2147483647"/>
-</xs:sequence>
-<xs:attribute name="id" type="ST_ResourceID" use="required"/>
-</xs:complexType>
+      <xs:complexType name="CT_NodeGroup">
+        <xs:sequence>
+          <xs:element ref="node" maxOccurs="2147483647"/>
+        </xs:sequence>
+        <xs:attribute name="id" type="ST_ResourceID" use="required"/>
+      </xs:complexType>
 
-<xs:complexType name="CT_BeamGroup">
-<xs:sequence>
-<xs:element ref="beam" maxOccurs="2147483647"/>
-</xs:sequence>
-<xs:attribute name="id" type="ST_ResourceID" use="required"/>
-</xs:complexType>
+      <xs:complexType name="CT_BeamGroup">
+        <xs:sequence>
+          <xs:element ref="beam" maxOccurs="2147483647"/>
+        </xs:sequence>
+        <xs:attribute name="id" type="ST_ResourceID" use="required"/>
+      </xs:complexType>
 
-<xs:complexType name="CT_Graph">
-<xs:element ref="nodegroup" />
-<xs:element ref="beamgroup" />
-<xs:attribute name="id" type="ST_ResourceID" use="required"/>
-<xs:attribute name="name" type="xs:string" use="optional"/>
-</xs:complexType>
+      <xs:complexType name="CT_Graph">
+        <xs:element ref="nodegroup" />
+        <xs:element ref="beamgroup" />
+        <xs:attribute name="id" type="ST_ResourceID" use="required"/>
+        <xs:attribute name="name" type="xs:string" use="optional"/>
+      </xs:complexType>
 
-<!-- Simple Types -->
-</xs:simpleType>
-<xs:simpleType name="ST_ResourceID">
-<xs:restriction base="xs:positiveInteger">
-<xs:maxExclusive value="2147483648"/>
-</xs:restriction>
-</xs:simpleType>
+      <!-- Simple Types -->
+    </xs:simpleType>
+    <xs:simpleType name="ST_ResourceID">
+      <xs:restriction base="xs:positiveInteger">
+        <xs:maxExclusive value="2147483648"/>
+      </xs:restriction>
+    </xs:simpleType>
 
-</xs:simpleType>
-<xs:simpleType name="ST_Number">
-<xs:restriction base="xs:double">
-<xs:whiteSpace value="collapse"/>
-<xs:pattern value="((\-|\+)?(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))((e|E)(\-|\+)?[0-9]+)?)"/>
-</xs:restriction>
-</xs:simpleType>
+  </xs:simpleType>
+  <xs:simpleType name="ST_Number">
+    <xs:restriction base="xs:double">
+      <xs:whiteSpace value="collapse"/>
+      <xs:pattern value="((\-|\+)?(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))((e|E)(\-|\+)?[0-9]+)?)"/>
+    </xs:restriction>
+  </xs:simpleType>
 
-<!-- Elements -->
-<xs:element name="nodegroup" type="CT_NodeGroup"/>
-<xs:element name="beamgroup" type="CT_BeamGroup" />
-<xs:element name="node" type="CT_Node"/>
-<xs:element name="beam" type="CT_Beam"/>
-<xs:element name="graph" type="CT_Graph"/>
+  <!-- Elements -->
+  <xs:element name="nodegroup" type="CT_NodeGroup"/>
+  <xs:element name="beamgroup" type="CT_BeamGroup" />
+  <xs:element name="node" type="CT_Node"/>
+  <xs:element name="beam" type="CT_Beam"/>
+  <xs:element name="graph" type="CT_Graph"/>
 
 </xs:schema>


### PR DESCRIPTION
- Updated schema & sample file to reflect 3mf naming convention.
- Updated library to read and write 3mf compatible .ltcx files

To do: 
- Write 3mf extension spec for NTLatticeGraph
- Add interpolation types for beams, smooting property for nodes
- Add reader/writer for .3mf files w/ .ltcx extension
- Possible extensions for surfaces? modifiers?
